### PR TITLE
Add MacOS building job in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,30 @@ jobs:
         - docker pull $DOCKER_IMAGE
       script:
         - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-manylinux2010_x86_64.sh
-      deploy:
-        provider: pypi
-        distributions: "sdist bdist_wheel"
-        skip_cleanup: true
-        user: __token__
-        # PyPI password should be stored on Travis CI as a secret env variable named PYPI_PASSWORD
-        on:
-          tags: true
-
+        - ls -l dist/
+    - os: osx
+      language: shell
+      sudo: required
+      install:
+        - brew cask install graalvm/tap/graalvm-ce-java11
+        - export PATH=/Library/Java/JavaVirtualMachines/graalvm-ce-java11-20.1.0/Contents/Home/bin:"$PATH"
+        - gu install native-image
+        - brew install swig
+        - pip3 install twine
+        - pyenv install 3.6.9
+        - pyenv install 3.7.5
+        - pyenv install 3.8.0
+      script:
+        - travis/build-macos.sh
+        - ls -l dist/
+deploy:
+  provider: pypi
+  distributions: "sdist bdist_wheel"
+  # Do not delete generated build files (i.e. wheels)
+  skip_cleanup: true
+  # Do not attempt to upload to PyPI an already uploaded wheel
+  skip_existing: true
+  user: __token__
+  # PyPI password should be stored on Travis CI as a secret env variable named PYPI_PASSWORD
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if sys.platform.startswith('linux'):
 elif sys.platform.startswith('darwin'):
     so_ext = '.dylib'
     capi_filename = 'libjgrapht_capi' + so_ext
-    extra_link_args = ['-Wl,-rpath,@loader_path']
+    extra_link_args = ['-Wl,-rpath,@loader_path/../python_jgrapht.libs']
 
 
 class BuildCapiCommand(Command):
@@ -144,7 +144,7 @@ setup(
     platforms=['any'],
     packages=setuptools.find_packages(),
     classifiers = [
-        'Development Status :: 3 - Beta',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',

--- a/travis/build-macos.sh
+++ b/travis/build-macos.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e -x
+
+pyenv global 3.6.9 3.7.5 3.8.0
+eval "$(pyenv init -)"
+
+# Build wheels for Python 3.6, 3.7, 3.8
+for PYBIN in /Users/travis/.pyenv/versions/3*/bin; do
+    "${PYBIN}/pip" install wheel
+    "${PYBIN}/python" setup.py bdist_wheel
+done
+
+# Install generated wheels and run the tests
+for PYBIN in /Users/travis/.pyenv/versions/3*/bin; do
+    "${PYBIN}/pip" install -r requirements/test.txt
+    "${PYBIN}/pip" install python-jgrapht --no-index -f dist/
+    "${PYBIN}/pytest"
+done


### PR DESCRIPTION
This adds MacOS wheel building on Travis.

Unfortunately, Travis [does not support Python on MacOS](https://docs.travis-ci.com/user/languages/python/) so we use pyenv in order to build wheels for Python versions 3.6, 3.7 and 3.8. Because pyenv downloads, builds and installs Python from source - which takes about 3 minute for each Python version - MacOS jobs for python-jgrapht take about twice the time of the Linux building jobs.

Known issues:
- `brew cask install graalvm/tap/graalvm-ce-java11` installs the latest GraalVM version, so adding it to the `PATH` needs to be more dynamic. So far, I have not found a good way to specify a version in brew cask install, and the project [doesn't seem interested](https://github.com/Homebrew/homebrew-cask/issues/471) in this. Maybe if we want to pin versions, downloading the darwin tarball from the GraalVM GitHub releases page would be more appropriate.