### PR TITLE
Remove auditwheel repair step from manylinux builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ if sys.platform.startswith('linux'):
     so_ext = '.so'
     capi_filename = 'libjgrapht_capi' + so_ext
     # Make sure that _backend.so will be able to load jgrapht_capi.so
-    runtime_library_dirs=['$ORIGIN/../jgrapht.libs']
+    runtime_library_dirs=['$ORIGIN']
 elif sys.platform.startswith('darwin'):
     so_ext = '.dylib'
     capi_filename = 'libjgrapht_capi' + so_ext
-    extra_link_args = ['-Wl,-rpath,@loader_path/../jgrapht.libs']
+    extra_link_args = ['-Wl,-rpath,@loader_path']
 
 
 class BuildCapiCommand(Command):
@@ -75,10 +75,10 @@ class BuildCapiCommand(Command):
         # inplace will is set to 1 when the develop command runs.
         # Copy the JgraphT C API directly to the development area
         if self.inplace:
-            lib_target_path = 'jgrapht.libs'
+            lib_target_path = self.package_name
         else:
-            lib_target_path = os.path.join(self.build_lib, 'jgrapht.libs')
-        self.mkpath(lib_target_path)
+            lib_target_path = os.path.join(self.build_lib, self.package_name)
+            self.mkpath(lib_target_path)
         self.copy_file(lib_source_path, os.path.join(lib_target_path, self.filename))
 
 


### PR DESCRIPTION
Building our Linux wheels with `auditwheel repair` causes the following two problems:

1. auditwheel bundles in the Linux wheel zlib which is [not necessary](https://github.com/pypa/auditwheel/issues/152)
2. auditwheel changes the RPATH of `_backend.so` from `$ORIGIN` which we manually specify in setup.py to `$ORIGIN/../jgrapht.libs` where it also places the bundled libz.so - because it assumes that `_backend.so` is the one linking to libz, which is not. While doing so it does not also move `jgrapht_capi.so` in `jgrapht.libs` and therefore `_backend.so` is no longer able to load `jgrapht_capi.so`. Furthermore, it does not set the RPATH of `jgrapht_capi.so` to `$ORIGIN/../jgrapht.libs` in order for the former to be able to load the bundled zlib, and `jgrapht_capi.so` ends up loading system's libz anyway.

What we were doing was to modify setup.py to place `jgrapht_capi.so` in `jgrapht.libs` to cope with auditwheel changing our RPATH. This worked but needed special care for Windows because AFAICT there is no RPATH equivalent in Windows, so the dll needs to be in the same directory with `_backend.so`.

With this approach though, we ended up with exactly the same result as with what we'd have without auditwheel repair but with a manylinux2010_x86_x64 tag, an unused libz bundled in our wheel (jgrapht_capi would still load the system libz) and a special handling for Windows in setup.py. 

This PR drops `auditwheel repair` in favor of a simple `python setup.py --plat-name=manylinux2010_x86_x64` which is required in order for pypi.org to accept the produced wheels.
