### PR TITLE
Add Windows building job in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,23 @@ jobs:
       script:
         - travis/build-macos.sh
         - ls -l dist/
+    - os: windows
+      language: shell
+      install:
+        - choco install pyenv-win
+        - export PATH="C:\Users\travis\.pyenv\pyenv-win\bin:C:\Users\travis\.pyenv\pyenv-win\shims:$PATH"
+        - pyenv install -q 3.6.8-amd64
+        - pyenv install -q 3.7.5-amd64
+        - pyenv install -q 3.8.0-amd64
+        - choco install maven --version=3.6.3
+        - export PATH="/c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.3/bin:$PATH"
+        - choco install graalvm --version=20.0.0
+        - export PATH="/c/Program Files/GraalVM/graalvm-ce-java11-20.0.0/bin:$PATH"
+        - choco install swig --version=4.0.1
+        - gu.cmd install native-image
+      script:
+        - travis/build.bat
+        - ls -l dist/
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ jobs:
     - os: windows
       language: shell
       install:
+        - choco install python --version=3.8.0
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        - python -m pip install twine
         - choco install pyenv-win
         - export PATH="C:\Users\travis\.pyenv\pyenv-win\bin:C:\Users\travis\.pyenv\pyenv-win\shims:$PATH"
         - pyenv install -q 3.6.8-amd64

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ class BuildCapiCommand(Command):
             print("")
             return False
         print("Found source at {}".format(self.src_dir))
+        # Additional CMake parameters should be set as environment variables
+        # before calling setup.py depending on the platform and toolchain.
         self.spawn(['cmake', '-B{}'.format(self.build_dir), '-H{}'.format(self.src_dir)])
         self.spawn(['cmake', '--build', self.build_dir])
         lib_source_path = os.path.join(self.build_dir, self.filename)

--- a/travis/build.bat
+++ b/travis/build.bat
@@ -1,0 +1,16 @@
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+:: Set the generator to VS 2017 and target architecture to x64
+SET CMAKE_GENERATOR=Visual Studio 15 2017 Win64
+:: Set the host architecture to x64, by default CMake selects x86
+SET CMAKE_GENERATOR_TOOLSET=host=x64
+
+:: Build, install and test 64-bit wheels for all supported Python versions
+FOR %%P IN (3.6.8 3.7.5 3.8.0) DO (
+    pyenv global %%P-amd64
+    pyenv exec python --version
+    pyenv exec python -m pip install -U pip
+    pyenv exec python -m pip install pytest wheel
+    pyenv exec python setup.py bdist_wheel
+    pyenv exec python -m pip install jgrapht --no-index -f dist
+    pyenv exec Scripts\pytest
+)


### PR DESCRIPTION
This PR adds Windows 10 64-bit Python 3.{6|7|8} wheel builds for jgrapht in Travis.

It uses the (early-stage) [Windows Travis environment](https://docs.travis-ci.com/user/reference/windows/) with the following tools:
- chocolatey to install dependencies (pyenv-win, maven, graalvm, swig)
- the preinstalled Microsoft Visual Studio 2017 to compile `jgrapht_capi.dll` and `_backend.pyd`
- pyenv-win to build wheels against multiple Python versions

Due to the fact that we need to call Visual Studio's `vcvars64.bat` in order to export some environment variables used later by the MSVC compiler, and Git Bash (which Travis provides) does not support "source" or "call" on a .bat script, the `python setup.py bdist_wheel` command and the entire building and testing script was written in `travis/build.bat`.

I never imagined that I would need to learn the syntax of a for loop in Windows batch, but there we go.