### PR TITLE
Custom PyPI deploy script for Windows builds due to a Travis bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,17 @@ jobs:
       script:
         - travis/build.bat
         - ls -l dist/
+      deploy:
+        # https://github.com/travis-ci/dpl/issues/1009
+        provider: script
+        script: bash ./travis/deploy.sh
+        # Do not delete generated build files (i.e. wheels)
+        skip_cleanup: true
+        # Do not attempt to upload to PyPI an already uploaded wheel
+        skip_existing: true
+        on:
+          tags: true
+
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+twine upload \
+    --username "${PYPI_USER:-__token__}" \
+    --password "$PYPI_PASSWORD" \
+    ./dist/*
+


### PR DESCRIPTION
On release [1.4.1.0rc2](https://travis-ci.org/github/d-michail/python-jgrapht/jobs/695890092) we discovered that Travis pypi deploy provider has a bug on Windows:  https://github.com/travis-ci/dpl/issues/1009.

This PR implements a workaround with a custom deploy script that calls twine