### PR TITLE
Fix PyPi deploy on Travis CI Windows jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ jobs:
     - os: windows
       language: shell
       install:
-        - choco install python --version=3.8.0
-        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
-        - python -m pip install twine
         - choco install pyenv-win
         - export PATH="C:\Users\travis\.pyenv\pyenv-win\bin:C:\Users\travis\.pyenv\pyenv-win\shims:$PATH"
         - pyenv install -q 3.6.8-amd64

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-twine upload \
-    --username "${PYPI_USER:-__token__}" \
-    --password "$PYPI_PASSWORD" \
-    ./dist/*
+pyenv global 3.8.0-amd64
+pyenv exec python -m pip install -U pip
+pyenv exec python -m pip install twine
+pyenv exec python -m twine --version
+pyenv exec python -m twine upload --username "${PYPI_USER:-__token__}" --password "$PYPI_PASSWORD" dist/*
 


### PR DESCRIPTION
This PR fixes the Windows PyPI deploy procedure for Windows builds introduced with https://github.com/d-michail/python-jgrapht/pull/7. This time the pipeline was tested on test.pypi.org so it is expected to work.

The problem was that pyenv-win is messing the PATH and the choco install'ed python on Windows. Therefore, the twine binary could not be found after the `build.bat` script (which calls pyenv global, etc) was executed.

Unfortunately Travis wasn't very helpful, with the only output being:

```
$ twine upload --verbose --username "__token__" --password "$PYPI_PASSWORD" --repository testpypi dist/*
The command "twine upload --verbose --username "__token__" --password "$PYPI_PASSWORD" --repository testpypi dist/*" exited with 1.
```

So it took a few extra hours of debugging.