### PR TITLE
Extracting positions from layout should use vertex number, not index.

### DIFF
--- a/jgrapht/drawing/draw_matplotlib.py
+++ b/jgrapht/drawing/draw_matplotlib.py
@@ -764,7 +764,7 @@ def layout(g, name=None, area=(0, 0, 10, 10), **kwargs):
     result = alg(g, area, **args)
     positions = {}
     for i, vertex in enumerate(g.vertices):
-        x, y = result.get_vertex_location(i)
+        x, y = result.get_vertex_location(vertex)
         positions[vertex] = (x, y)
 
     return positions


### PR DESCRIPTION
To convert the output of the layout algorithm to the dictionary mapping vertices to their positions one must use the vertex number, not the vertex index.
This is particularly evident if the graph is a masked subgraph, in witch the i-th vertex needs not to be i.